### PR TITLE
Fix development issues on macOS

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Turned off sandbox and give network ability on macOS.
If you still can't build this project on macOS please modify 'pubspec.yaml' and try to change 
[environment: sdk: '>=3.0.0-35.0.dev <4.0.0'] 
to 
[environment: sdk: '>=2.18.0 <4.0.0']