### PR TITLE
Add Dart script and update macOS workflow for Podfile fix

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,12 +1,9 @@
 name: Macos Release
-
 on:
   workflow_dispatch:
 
-
-
 jobs:
-  version:
+  Version:
     runs-on: windows-latest
     permissions:
       contents: read
@@ -15,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.5
 
-      - name: Extract Version from pubspec.yaml
+      - name: Extract version from pubspec yaml
         id: extract_version
         run: |
           $VERSION = Select-String  -Path ".\pubspec.yaml" -Pattern "version: (\d+\.\d+\.\d+)" -CaseSensitive | ForEach-Object{ $_.Matches.Groups[1].Value }
@@ -25,13 +22,12 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: read
-    needs: version
+    needs: Version
     steps:
-
       - name: Checkout the code
         uses: actions/checkout@v4.1.5
 
-      - name: Set up Node.js
+      - name: Set up node js
         uses: actions/setup-node@v3
         with:
           node-version: '20'
@@ -40,60 +36,81 @@ jobs:
         run: npm install -g appdmg
 
       - name: Install flutter
-        uses: subosito/flutter-action@v2.14.0
+        uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.29.2"
+          flutter-version: "3.29.0"
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
           cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:'
 
-      - name: Enable linux-desktop for flutter
+      - name: Print Environment Info
+        run: |
+          echo "--- Flutter Version --- "
+          flutter --version --verbose
+          echo "--- Dart Version --- "
+          dart --version
+          echo "--- macOS Version --- "
+          sw_vers
+          echo "--- Xcode Version --- "
+          xcodebuild -version
+          echo "--- Xcode SDKs --- "
+          xcodebuild -showsdks
+          echo "--- CocoaPods Version --- "
+          pod --version
+          echo "--- Node Version --- "
+          node --version
+          echo "--- npm Version --- "
+          npm --version
+          echo "--- appdmg Version --- "
+          appdmg --version || echo "appdmg not found or version command failed"
+          echo "--- Ruby Version --- "
+          ruby --version
+          echo "--- RubyGems Version --- "
+          gem --version
+          echo "--- System Info --- "
+          uname -a
+          echo "--- pubspec.lock loader_overlay --- "
+          grep loader_overlay pubspec.lock | cat
+          echo "--- Flutter Pub Deps --- "
+          flutter pub deps
+
+      - name: Enable macos desktop for flutter
         run: flutter config --enable-macos-desktop && export PATH="$PATH":"$HOME/.pub-cache/bin"
 
-      - name: Copy MacOS related files
-        run: |
-         cp macos/Runner/Release.entitlements .
-         cp -r macos/Runner/Assets.xcassets .
-         cp -r macos/packaging .
+      - name: Ensure macos directory exists
+        run: flutter create --platform macos .
 
-      - name: Recreate MacOS directory
+      - name: Remove RunnerTests target from Podfile using Dart script
         run: |
-         rm -rf macos
-         flutter create --platform macos .
-
-      - name: Replace MacOS files
-        run: |
-         mv packaging macos/
-         cp -f Release.entitlements macos/Runner/
-         cp -rf Assets.xcassets macos/Runner/
+          echo "Running Dart script to remove RunnerTests target..."
+          dart run scripts/fix_podfile_for_build_macos.dart macos/Podfile
+          echo "--- Podfile after Dart script modification --- "
+          cat macos/Podfile
 
       - name: Get dependencies
         run: flutter pub get
 
-      - name: Install flutter_distributor
+      - name: Install flutter distributor
         run: dart pub global activate flutter_distributor
 
       - name: Start the build process
         run: flutter_distributor package --platform macos --targets dmg
 
-      - name: Debug
-        run: ls dist/${{ needs.version.outputs.version }}
-
-      - name: Rename dmg File
-        run: mv dist/${{ needs.version.outputs.version }}/brisk-${{ needs.version.outputs.version }}+${{ needs.version.outputs.version }}-macos.dmg ./Brisk-${{ needs.version.outputs.version }}-macos-x64.dmg
+      - name: Rename dmg file
+        run: mv dist/${{ needs.version.outputs.version }}/brisk-${{ needs.version.outputs.version }}-macos.dmg ./Brisk-${{ needs.version.outputs.version }}-macos.dmg
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.3
         with:
           name: brisk-dmg
-          path: Brisk-${{ needs.version.outputs.version }}-macos-x64.dmg
+          path: Brisk-${{ needs.version.outputs.version }}-macos.dmg
           retention-days: 1
 
 
   Release:
     runs-on: ubuntu-latest
-    needs: [Build-macos, version]
+    needs: [Build-macos, Version]
     permissions:
       contents: write
     steps:
@@ -101,12 +118,12 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4.1.5
 
-      - name: Donwload artifact package
+      - name: Download artifact package
         uses: actions/download-artifact@v4.1.0
         with:
           name: brisk-dmg
 
-      - name: LS
+      - name: List files
         run: ls .
 
       - name: Release the changes
@@ -116,7 +133,7 @@ jobs:
         with:
           tag_name: v${{ needs.version.outputs.version }}
           body_path: ./.github/release.md
-          files: ./Brisk-${{ needs.version.outputs.version }}-macos-x64.dmg
+          files: ./Brisk-${{ needs.version.outputs.version }}-macos.dmg
 
 
 

--- a/scripts/fix_podfile_for_build_macos.dart
+++ b/scripts/fix_podfile_for_build_macos.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+void main(List<String> arguments) async {
+  if (arguments.length != 1) {
+    print('Usage: dart fix_podfile_for_build_macos.dart <path_to_podfile>');
+    exit(1);
+  }
+
+  final podfilePath = arguments[0];
+  final podfile = File(podfilePath);
+  final tempPodfilePath = '$podfilePath.tmp';
+  final tempPodfile = File(tempPodfilePath);
+
+  if (!await podfile.exists()) {
+    print('Error: Podfile not found at $podfilePath');
+    exit(1);
+  }
+
+  print('Processing Podfile: $podfilePath to remove RunnerTests target...');
+
+  bool inTargetBlock = false;
+  int nestLevel = 0;
+  int linesSkipped = 0;
+  final linesToWrite = <String>[];
+
+  // Read all lines first, then iterate
+  final lines = await podfile.readAsLines();
+  for (final line in lines) {
+    final trimmedLine = line.trim();
+
+    if (trimmedLine.startsWith("target 'RunnerTests' do")) {
+      print("  Found start of 'RunnerTests' target block at line: ${line.trim()}");
+      inTargetBlock = true;
+      nestLevel = 1;
+      linesSkipped++; // Also skip the starting line
+      continue;
+    }
+
+    if (inTargetBlock) {
+      if (trimmedLine.endsWith(' do')) {
+        nestLevel++;
+      } else if (trimmedLine == 'end') {
+        nestLevel--;
+        if (nestLevel == 0) {
+          print("  Found end of 'RunnerTests' target block.");
+          inTargetBlock = false;
+          linesSkipped++; // Skip the ending line
+          continue;
+        }
+      }
+      // Still inside the target block or nested block within it
+      linesSkipped++;
+      continue;
+    }
+
+    // If not skipping, add the line to be written
+    linesToWrite.add(line);
+  }
+
+  if (inTargetBlock) {
+    print("Warning: Reached end of file while still inside RunnerTests block. Podfile might be malformed.");
+  }
+
+  try {
+    // Write the modified content to the temporary file
+    await tempPodfile.writeAsString(linesToWrite.join('\n') + '\n'); // Add trailing newline
+
+    // Replace original file with temporary file
+    await tempPodfile.rename(podfilePath);
+    print('Successfully updated $podfilePath. Skipped $linesSkipped lines.');
+  } catch (e) {
+    print('Error writing or renaming file: $e');
+    // Attempt to clean up temp file
+    if (await tempPodfile.exists()) {
+      try {
+        await tempPodfile.delete();
+      } catch (delErr) {
+        print("Error deleting temporary file: $delErr");
+      }
+    }
+    exit(1);
+  }
+}


### PR DESCRIPTION
Introduce a Dart script to remove the `RunnerTests` target from the macOS Podfile, ensuring smoother builds. Update the GitHub Actions macOS workflow to integrate the script and improve overall clarity, consistency, and functionality.