### PR TITLE
Issue#100 Ensure Flutter binding initialization on macOS startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,10 @@ import 'util/settings_cache.dart';
 
 // TODO Fix resizing the window when a row is selected
 void main() async {
+  if(Platform.isMacOS) {
+    //An exception is thrown at the start of the app if this is not called on macOS
+    WidgetsFlutterBinding.ensureInitialized();
+  }
   await Logger.init();
   FlutterError.onError = (FlutterErrorDetails details) {
     FlutterError.presentError(details);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,10 +37,7 @@ import 'util/settings_cache.dart';
 
 // TODO Fix resizing the window when a row is selected
 void main() async {
-  if(Platform.isMacOS) {
-    //An exception is thrown at the start of the app if this is not called on macOS
-    WidgetsFlutterBinding.ensureInitialized();
-  }
+  WidgetsFlutterBinding.ensureInitialized();
   await Logger.init();
   FlutterError.onError = (FlutterErrorDetails details) {
     FlutterError.presentError(details);
@@ -48,7 +45,6 @@ void main() async {
     Logger.log(details.stack);
     Logger.log(details.exception);
   };
-  WidgetsFlutterBinding.ensureInitialized();
   await migrateDatabaseLocation();
   await windowManager.ensureInitialized();
   tz.initializeTimeZones();


### PR DESCRIPTION
Add `WidgetsFlutterBinding.ensureInitialized()` to prevent startup exceptions on macOS. This ensures proper app initialization specific to the macOS platform.