### PR TITLE
#92 Adjust column width for 'Progress' in download grid.

### DIFF
--- a/lib/widget/download/download_grid.dart
+++ b/lib/widget/download/download_grid.dart
@@ -101,7 +101,7 @@ class _DownloadGridState extends State<DownloadGrid> {
       ),
       PlutoColumn(
         readOnly: true,
-        width: 95,
+        width: 100,
         title: 'Progress',
         field: 'progress',
         type: PlutoColumnType.text(),


### PR DESCRIPTION
Fix UI issues for macos #92
Increased the column width from 95 to 100 to improve readability and ensure consistent alignment with other grid elements. This provides a better user experience in displaying data.

![image](https://github.com/user-attachments/assets/9fff2a59-97d2-4414-a5cd-25c023afcb81)
